### PR TITLE
Drop `trifl.java` require in core namespace

### DIFF
--- a/src/rfc5322/core.clj
+++ b/src/rfc5322/core.clj
@@ -3,8 +3,7 @@
     [instaparse.core :as instaparse]
     [rfc5322.xform :as xform]
     [rfc5322.parser :as parser]
-    [taoensso.timbre :as log]
-    [trifl.java :refer [show-methods]]))
+    [taoensso.timbre :as log]))
 
 (defn log-and-passthrough
   [x level msg]


### PR DESCRIPTION
`rfc5322.core` requires `[trifl.java …]` but the package dependency on `clojusc/trifl` seems to be only declared in the `:dev` lein profile. So the released package has this issue where `clojusc/trifl` is not already in the classpath:

```
$ clj -Sdeps '{:deps {clojusc/rfc5322 {:mvn/version "0.5.0"}}}'
Clojure 1.10.0
user=> (require 'rfc5322.core)
Syntax error (FileNotFoundException) compiling at (core.clj:1:1).
Could not locate trifl/java__init.class, trifl/java.clj or trifl/java.cljc on classpath.
```

I expect that `trifl.java` was intended to be used as a debugging convenience during dev, because it is not used by the code. So this particular `require` can be dropped?